### PR TITLE
start sample using docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # activiti-examples
 This repository contains Activiti 7.x Examples
+
+## spring-boot-sample-activiti
+
+This shows the v7 engine in action by providing a project based upon the starter. You can hit rest endpoints on this project to start process instances and action tasks.
+
+This project includes a quickstart that invokes a docker-compose to start with the engine components running as separate services.
+
+## emergency-call-center
+
+This is a demo of using the engine in a microservices environment. Here only the core engine is used, not all of the REST services.

--- a/spring-boot-sample-activiti/README.md
+++ b/spring-boot-sample-activiti/README.md
@@ -4,25 +4,23 @@ This sample program demonstrates the use of a HAL REST API for the Activiti BPM 
 
 The REST endpoints are also secured using keycloak as an identity provider.
 
-## Assumed Keycloak Setup
+## Pre-requisites
 
-The keycloak setup used by this example can be replicated by importing the provided keycloak realm json file. The user 'testuser' with password 'password' is used for accessing endpoints. The user 'hr'/'password' is in the 'hr' group. The user 'client'/'client' is for using admin client to look up groups.
+Check out the equivalent branch of the main Activiti project and run mvn clean install -DskipTests
 
-To run using a standalone keycloak, download keycloak and run using the following from the keycloak bin directory - ./standalone.sh -Djboss.socket.binding.port-offset=100
+## Quickstart
 
-The port-offset is important as otherwise Activiti and Keycloak will have a port confllict.
+1) Add this entry to your hosts file - 127.0.0.1       activiti-keycloak
+2) Run start.sh or start.bat from this directory
+3) Go to http://localhost:8090/v1/process-instances
+4) To reach the endpoint you'll need to enter testuser/password at the keycloak prompt
+5) To create process instances you'll need to use the postman collection
 
-## How to run
+## Alternative Setups
 
-To run the sample, run from IDE using the Application.java file but first ensure you have keycloak and rabbitmq docker containers running (see below). To hit an endpoint in the browser, go to http://localhost:8080/process-definitions
+It is also possible to just start the core services directly from the main Activiti project and then start only this sample application using the IDE. To do this rabbitmq also needs to be added to hosts file or changed in application.properties to localhost.
 
-A reference dockerfile is also provided (separately) which applies the keycloak json configuration file for the realm to the jboss/keycloak:3.2.0.Final image.
-
-To run it first have docker installed then go to the docker directory and do 'docker build . -t activiti-keycloak' Then execute 'docker run -p 8180:8080 --name keycloak -i -t activiti-keycloak'
-
-If you get a container already in use error when running the docker container then do a docker rm with the id of the running container and try again. To access the admin console for the container go to http://localhost:8180/auth/admin/springboot/console/ and log in as admin/admin. (This reference docker is based upon reference docker is based upon https://github.com/dfranssen/docker-keycloak-import-realm. Note that the admin user has been included in the springboot-realm.json.)
-
-To run the rabbitmq container to go the docker directory and run docker-compose up.
+It is also possible to run keycloak and rabbitmq standalone. See the main Activiti project's docker notes for this.
 
 ## Postman
 

--- a/spring-boot-sample-activiti/docker-compose.yml
+++ b/spring-boot-sample-activiti/docker-compose.yml
@@ -1,0 +1,21 @@
+rabbitmq:
+  image: rabbitmq:management
+  ports:
+    - "5672:5672"
+    - "15672:15672"
+activiti-sample:
+  image: activiti-sample:latest
+  ports:
+    - "8090:8090"
+  links:
+    - activiti-keycloak:activiti-keycloak
+    - rabbitmq:rabbitmq
+activiti-keycloak:
+  image: activiti-keycloak:latest
+  ports:
+    - "8080:8080"
+#elasticsearch:
+#  image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
+#  ports:
+#    - "9200:9200"
+#    - "9300:9300"

--- a/spring-boot-sample-activiti/docker-compose.yml
+++ b/spring-boot-sample-activiti/docker-compose.yml
@@ -10,6 +10,13 @@ activiti-sample:
   links:
     - activiti-keycloak:activiti-keycloak
     - rabbitmq:rabbitmq
+activiti-audit:
+  image: activiti-audit:latest
+  ports:
+    - "8082:8082"
+  links:
+    - activiti-keycloak:activiti-keycloak
+    - rabbitmq:rabbitmq
 activiti-keycloak:
   image: activiti-keycloak:latest
   ports:

--- a/spring-boot-sample-activiti/pom.xml
+++ b/spring-boot-sample-activiti/pom.xml
@@ -78,12 +78,6 @@
                 </assembly>
                 <cmd>java -jar maven/${project.artifactId}-${project.version}.jar</cmd>
               </build>
-              <run>
-                <wait>
-                  <log>org.activiti.*Started Application</log>
-                  <time>40000</time>
-                </wait>
-              </run>
             </image>
           </images>
         </configuration>

--- a/spring-boot-sample-activiti/src/main/resources/application.properties
+++ b/spring-boot-sample-activiti/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 server.port=8090
 spring.application.name=my-app
+spring.cloud.stream.bindings.auditProducer.destination=engineEvents
+spring.cloud.stream.bindings.auditProducer.contentType=application/json
 spring.cloud.stream.bindings.myCmdResults.destination=commandResults
 spring.cloud.stream.bindings.myCmdResults.group=myCmdGroup
 spring.cloud.stream.bindings.myCmdResults.contentType=application/json

--- a/spring-boot-sample-activiti/start.bat
+++ b/spring-boot-sample-activiti/start.bat
@@ -1,0 +1,8 @@
+REM stop if already running
+docker-compose down
+
+REM run build to build docker image
+
+mvn clean install -DskipTests
+
+docker-compose up

--- a/spring-boot-sample-activiti/start.sh
+++ b/spring-boot-sample-activiti/start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#stop if already running
+docker-compose down
+
+# run build to build docker image
+
+mvn clean install -DskipTests
+
+docker-compose up


### PR DESCRIPTION
This was previously done from main Activiti repo. Do from starter instead. Also start the audit service.